### PR TITLE
Auth tokens don't expire now

### DIFF
--- a/src/api/users/auth.route.js
+++ b/src/api/users/auth.route.js
@@ -130,7 +130,7 @@ router.post('/signup', /* authLimiter, */ async (req, res) => {
 
     res.cookie('auth_token', newUser.authorization, {
       httpOnly: true,
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+      maxAge: 9999 * 24 * 60 * 60 * 1000,
       sameSite: 'strict',
       secure: process.env.NODE_ENV === 'production'
     });


### PR DESCRIPTION
the current way auth is handled is awful because once you login, the client thinks you're logged in forever. it never checks with the server to see if the cookie is still valid. this is a bandaid fix that I won't remove for the foreseeable future because I'd have to implement cookies that properly expire + make the frontend check if the cookie is still valid when the page loads

Users get a vague "no authorization" error if they login and then wait 7 days because the auth cookie expired which is really annoying. This fixes that