### PR TITLE
add file uploads/downloads in containers

### DIFF
--- a/src/utils/spaces.js
+++ b/src/utils/spaces.js
@@ -111,7 +111,7 @@ export const createContainer = async (password, type, authorization) => {
 
     const container = await docker.createContainer({
       Image: config.image,
-      Env: config.env(password, port),
+      Env: [...config.env(password, port), "SELKIES_FILE_TRANSFERS=upload,download", "SELKIES_UI_SIDEBAR_SHOW_FILES=True"],
       ExposedPorts: { [config.port]: {} },
       HostConfig: hostConfig,
     });


### PR DESCRIPTION
<img width="274" height="703" alt="image" src="https://github.com/user-attachments/assets/dc6fa6e5-e81a-4207-8a45-f42aa6810049" />

Users can now upload/download files they've created in Blender and KiCad docker containers