### PR TITLE
Update Hackatime API key link

### DIFF
--- a/client/src/lib/Settings.svelte
+++ b/client/src/lib/Settings.svelte
@@ -362,7 +362,7 @@
       <small
         >This key is used for integration with Hackatime. Find your hackatime
         API key <a
-          href="https://hackatime.hackclub.com/my/settings/access"
+          href="https://hackatime.hackclub.com/api-key"
           target="_blank"
           rel="noopener noreferrer">here</a
         > (look in the "Wakatime config" section)</small

--- a/client/src/lib/Settings.svelte
+++ b/client/src/lib/Settings.svelte
@@ -1,4 +1,4 @@
-<script>
+ <script>
   import { createEventDispatcher, onMount } from "svelte";
   import { API_BASE } from "../config.js";
   import { userData } from "../stores/user.svelte";
@@ -365,7 +365,7 @@
           href="https://hackatime.hackclub.com/api-key"
           target="_blank"
           rel="noopener noreferrer">here</a
-        > (look in the "Wakatime config" section)</small
+        > (Click the key to copy it and paste it here)</small
       >
     </div>
 


### PR DESCRIPTION
The link previously took you to Hackatimes settings page where you can find your API key but need to click a few buttons and look around. The https://hackatime.hackclub.com/api-key link shows your API Key right on the page where you can click to copy making it a nicer and smoother experiance for people using spaces.